### PR TITLE
feat: add basic navigation structure and types

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { RootStackParamList, AuthStackParamList } from '../types/navigation';
+import LoginScreen from '../screens/auth/LoginScreen';
+
+const RootStack = createStackNavigator<RootStackParamList>();
+const AuthStack = createStackNavigator<AuthStackParamList>();
+
+const AuthNavigator = () => (
+  <AuthStack.Navigator screenOptions={{ headerShown: false }}>
+    <AuthStack.Screen name="Login" component={LoginScreen} />
+  </AuthStack.Navigator>
+);
+
+export const RootNavigator = () => {
+  const isAuthenticated = false;
+
+  return (
+    <NavigationContainer>
+      <RootStack.Navigator screenOptions={{ headerShown: false }}>
+        <RootStack.Screen name="Auth" component={AuthNavigator} />
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+};

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,20 @@
+export type AuthStackParamList = {
+    Login: undefined;
+    Register: undefined;
+    ForgotPassword: undefined;
+};
+  export type MainTabParamList = {
+    Home: undefined;
+    Discover: undefined;
+    CreatePost: undefined;
+    Notifications: undefined;
+    Profile: { userId?: string };
+};
+  export type RootStackParamList = {
+    Auth: undefined;
+    MainApp: undefined;
+    Story: { storyId: string };
+    Comments: { postId: string };
+    Settings: undefined;
+    UserProfile: { userId: string };
+};


### PR DESCRIPTION
# Navigation Structure and Types Setup

## Description
This PR implements the foundational navigation structure and type definitions for the Lumenix app. It establishes the basic routing architecture using React Navigation with TypeScript support.

## Changes
- Added navigation type definitions for:
  - Authentication flow (Login, Register, ForgotPassword)
  - Main tab navigation
  - Root stack navigation
- Implemented basic navigation structure with AuthNavigator
- Set up minimal working example with LoginScreen route

## Testing
- Verify navigation types are properly defined
- Confirm basic navigation structure compiles without errors
- Test that LoginScreen route is accessible

## Dependencies Added
- @react-navigation/native
- @react-navigation/stack
- react-native-screens
- react-native-safe-area-context

## Next Steps
- Implement authentication screens
- Set up main tab navigation
- Add screen components

## Related Issues
[Add any related issue numbers here]