### PR TITLE
feat(redux): add redux store setup and provider, pluse added missing …

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { Provider } from 'react-redux';
 import { RootStackParamList, AuthStackParamList } from '../types/navigation';
+import { store } from '../store';
+
+// Auth Screen
 import LoginScreen from '../screens/auth/LoginScreen';
 
 const RootStack = createStackNavigator<RootStackParamList>();
@@ -13,14 +17,15 @@ const AuthNavigator = () => (
   </AuthStack.Navigator>
 );
 
+// Root component with Redux Provider
 export const RootNavigator = () => {
-//   const isAuthenticated = false;
-
   return (
-    <NavigationContainer>
-      <RootStack.Navigator screenOptions={{ headerShown: false }}>
-        <RootStack.Screen name="Auth" component={AuthNavigator} />
-      </RootStack.Navigator>
-    </NavigationContainer>
+    <Provider store={store}>
+      <NavigationContainer>
+        <RootStack.Navigator screenOptions={{ headerShown: false }}>
+          <RootStack.Screen name="Auth" component={AuthNavigator} />
+        </RootStack.Navigator>
+      </NavigationContainer>
+    </Provider>
   );
 };

--- a/src/screens/auth/ForgotPasswordScreen.tsx
+++ b/src/screens/auth/ForgotPasswordScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { StackScreenProps } from '@react-navigation/stack';
+import { AuthStackParamList } from '../../types/navigation';
+
+type Props = StackScreenProps<AuthStackParamList, 'ForgotPassword'>;
+
+const ForgotPasswordScreen: React.FC<Props> = () => {
+  return (
+    <View style={{flex:1, justifyContent:'center', alignItems:'center'}}>
+      <Text>Forgot Password Screen</Text>
+    </View>
+  );
+};
+
+export default ForgotPasswordScreen;

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './index';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,17 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './slices/authSlice';
+import uiReducer from './slices/uiSlice';
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+    ui: uiReducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,0 +1,48 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface User {
+  id: string;
+  username: string;
+  email: string;
+}
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+  token: null,
+  isLoading: false,
+  error: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser: (state, action: PayloadAction<User | null>) => {
+      state.user = action.payload;
+    },
+    setToken: (state, action: PayloadAction<string | null>) => {
+      state.token = action.payload;
+    },
+    setLoading: (state, action: PayloadAction<boolean>) => {
+      state.isLoading = action.payload;
+    },
+    setError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+    },
+    logout: (state) => {
+      state.user = null;
+      state.token = null;
+      state.error = null;
+    },
+  },
+});
+
+export const { setUser, setToken, setLoading, setError, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface UIState {
+  isRefreshing: boolean;
+  theme: 'light' | 'dark';
+}
+
+const initialState: UIState = {
+  isRefreshing: false,
+  theme: 'light',
+};
+
+const uiSlice = createSlice({
+  name: 'ui',
+  initialState,
+  reducers: {
+    setRefreshing: (state, action: PayloadAction<boolean>) => {
+      state.isRefreshing = action.payload;
+    },
+    setTheme: (state, action: PayloadAction<'light' | 'dark'>) => {
+      state.theme = action.payload;
+    },
+  },
+});
+
+export const { setRefreshing, setTheme } = uiSlice.actions;
+export default uiSlice.reducer;


### PR DESCRIPTION
# Redux Store Setup

## Description
This PR implements Redux store configuration with @reduxjs/toolkit for state management in the Lumenix app.

## Changes
- Set up Redux store configuration
- Add auth slice for user state management
- Add ui slice for app-wide UI state
- Add typed hooks for Redux usage
- Integrate Redux Provider with existing navigation structure

## Technical Details
- Used createSlice for type-safe reducer creation
- Added TypeScript types for store state and dispatch
- Configured middleware with serializableCheck disabled
- Maintained existing navigation structure

## Testing
- Verify store is properly configured
- Confirm navigation structure works with Redux Provider
- Check TypeScript types are working correctly

## Dependencies Used
- @reduxjs/toolkit
- react-redux

## Next Steps
- Set up API integration
- Implement authentication flow
- Add persistent storage for auth state

## Related Issues
[Add issue numbers if any]